### PR TITLE
Disable ctrl-alt-del with systemd module

### DIFF
--- a/tasks/rhel7stig/misc.yml
+++ b/tasks/rhel7stig/misc.yml
@@ -46,12 +46,11 @@
     - always
 
 - name: V-71993 - The x86 Ctrl-Alt-Delete key sequence must be disabled
-  command: systemctl mask ctrl-alt-del.target
-  when:
-    - security_rhel7_disable_ctrl_alt_delete | bool
-    - cad_mask_check.rc != 3
-  notify:
-    - reload systemd
+  systemd:
+    name: ctrl-alt-del.target
+    enabled: no
+    masked: yes
+    daemon_reload: yes
   tags:
     - high
     - misc

--- a/tasks/rhel7stig/misc.yml
+++ b/tasks/rhel7stig/misc.yml
@@ -35,16 +35,6 @@
     - misc
     - V-71985
 
-# This returns an exit code of 0 if it's running, 3 if it's masked.
-- name: Check if ctrl-alt-del.target is already masked
-  command: systemctl status ctrl-alt-del.target
-  register: cad_mask_check
-  check_mode: no
-  changed_when: False
-  failed_when: cad_mask_check.rc not in [0,3]
-  tags:
-    - always
-
 - name: V-71993 - The x86 Ctrl-Alt-Delete key sequence must be disabled
   systemd:
     name: ctrl-alt-del.target


### PR DESCRIPTION
Rather than do a check to see if ctrl-alt-del is masked, you can just use the systemd module for idempotence. 

In RHEL 7.4 there is also a new "CtrlAltDelBurstAction" that needs disabled but I'll add that in another PR.