### PR TITLE
Use a variable to set lifetime limit of password

### DIFF
--- a/tasks/rhel7stig/accounts.yml
+++ b/tasks/rhel7stig/accounts.yml
@@ -98,11 +98,11 @@
 # NOTE(mhayden): The "is mapping" check is required below because some users
 # may be attached to a Kerberos realm and they may not have shadow data on the
 # system. See bug 1659232 for more details.
-- name: Set maximum password lifetime limit to 60 days for interactive accounts
-  shell: "chage -M 60 {{ item.name }}"
+- name: "Set maximum password lifetime limit to {{ security_password_max_lifetime_days|default(60) }} days for interactive accounts"
+  shell: "chage -M {{ security_password_max_lifetime_days|default(60) }} {{ item.name }}"
   when:
     - item.shadow is mapping
-    - item.shadow.max_days > 60
+    - item.shadow.max_days > (security_password_max_lifetime_days|default(60))
     - security_set_maximum_password_lifetime | bool
   with_items:
     - "{{ interactive_user_list.users }}"


### PR DESCRIPTION
In V-71929 it seems like the maximum password limit can be set to a variable, however in V-71931 the hardcoded 60 is used. This change proposes to use the variable for the latter.

I am proposing this due to our own internal use, since PCI-DSS mandates in section 8.2.4 that passwords be rotated at least every 90 days, so using the variable makes sense.

Note: if the role was applied with 60 as the default and you wanted to change it to 90 for existing users, it'll remain at 60. I haven't yet come up with a reasonable solution for that problem.