### PR TITLE
Fix security_shadow_utils_create_home boolean

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -186,7 +186,7 @@ security_shadow_utils_fail_delay: 4                          # V-71951
 # Set a umask for all authenticated users.
 # security_shadow_utils_umask: '077'                         # V-71995
 # Create home directories for new users by default.
-security_shadow_utils_create_home: yes                       # V-72013
+security_shadow_utils_create_home: "yes"                     # V-72013
 # How many old user password to remember to prevent password re-use.
 #security_password_remember_password: 5                      # V-71933
 # Disable user accounts if the password expires.


### PR DESCRIPTION
Fix security_shadow_utils_create_home so it's not evaluated to True. Quoting yes will force a string (yes instead of True).
See https://github.com/ansible/ansible/issues/11905