### PR TITLE
Use state: present instead of deprecated state: installed

### DIFF
--- a/tasks/rhel7stig/apt.yml
+++ b/tasks/rhel7stig/apt.yml
@@ -16,7 +16,7 @@
 - name: Ensure debsums is installed
   apt:
     name: debsums
-    state: installed
+    state: present
   when: security_check_package_checksums | bool
 
 - name: Gather debsums report


### PR DESCRIPTION
Using `state: installed` with the `apt` module is deprecated and will not work on Ansible 2.9+. This PR changes `state: installed` to `state: present`.