### PR TITLE
A variety of updates and corrections.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -221,7 +221,7 @@ security_disable_gdm_timed_login: yes                        # V-71955
 # Enable session locking for graphical logins.
 security_lock_session: no                                    # V-71891
 # Set a timer (in seconds) when an inactive session is locked.
-security_lock_session_inactive_delay: 900                    # V-71893
+security_lock_session_inactive_delay: 'uint32 900'           # V-71893
 # Prevent users from modifying session lock settings.
 security_lock_session_override_user: yes                     # RHEL-07-010071
 # Lock a session (start screensaver) when a session is inactive.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -227,7 +227,7 @@ security_lock_session_override_user: yes                     # RHEL-07-010071
 # Lock a session (start screensaver) when a session is inactive.
 security_lock_session_when_inactive: yes                     # V-71893
 # Time after screensaver starts when user login is required.
-security_lock_session_screensaver_lock_delay: 5              # V-71901
+security_lock_session_screensaver_lock_delay: 'uint32 5'     # V-71901
 # Enable a login banner and set the text for the banner.
 security_enable_graphical_login_message: yes                 # V-71859
 security_enable_graphical_login_message_text: >

--- a/tasks/rhel7stig/auth.yml
+++ b/tasks/rhel7stig/auth.yml
@@ -48,15 +48,15 @@
 
 - name: Prevent users with blank or null passwords from authenticating (Red Hat)
   lineinfile:
-    dest: "{{ pam_auth_file }}"
+    dest: "{{ item }}"
     state: present
-    regexp: "^({{ item }}.*sufficient.*)nullok(.*)$"
+    regexp: "^(.*sufficient.*)nullok(.*)$"
     line: '\1\2'
     backup: yes
     backrefs: yes
   with_items:
-    - auth
-    - password
+    - "{{ pam_auth_file }}"
+    - "{{ pam_password_file }}"
   when:
     - ansible_os_family == 'RedHat'
     - security_disallow_blank_password_login | bool

--- a/vars/redhat.yml
+++ b/vars/redhat.yml
@@ -78,8 +78,6 @@ stig_packages_rhel7:
       - clamav-filesystem
       - clamav-lib
       - clamav-scanner-systemd
-      - clamav-server-systemd
-      - clamav-server
       - clamav-update
     state: "{{ security_package_state }}"
     enabled: "{{ security_enable_virus_scanner }}"


### PR DESCRIPTION
Both 057005a and cec2fe3 are changing the resulting values by prefxing 'uint32 ' as specified by the STIG. Verified using SCAP Compliance Checker 5.3 (SCC) from DISA and RHEL STIG v2.r6.

35b49bb: task was broken for the regex was not matching 100% nor was password-auth being updated. Both system-auth and password-auth are now working with all occurrences of nullok being removed for CentOS 7. Verified the change using SCC 5.3 RHEL v2r6.

9ef4307: Including the packages clamav-server and clamav-server-systemd breaks the role on CentOS 7. I have some reservations on their removal for I have no idea why the packages were ever included. I found no history of them in the current CentOS 7 and Fedora 31 repositories. Perhaps someone was using a third party repository?